### PR TITLE
Add interpolation

### DIFF
--- a/robotiq_gripper_gazebo_plugins/CMakeLists.txt
+++ b/robotiq_gripper_gazebo_plugins/CMakeLists.txt
@@ -42,6 +42,7 @@ link_directories(${gazebo_dev_LIBRARY_DIRS})
 # robotiq finger gripper plugin
 add_library(robotiq_gripper_gazebo_plugin SHARED
   src/RobotiqGripperPlugin.cpp
+  src/spline.cpp
 )
 
 ament_target_dependencies(robotiq_gripper_gazebo_plugin

--- a/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
+++ b/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
@@ -91,7 +91,7 @@ namespace gazebo
     // Documentation inherited.
     public: void Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
-    /// \ brief Handle wimulation reset.
+    /// \ brief Handle simulation reset.
     public: void Reset();
 
     /// \brief World pointer.

--- a/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
+++ b/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
@@ -28,6 +28,8 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo_ros/node.hpp>
 
+#include <robotiq_gripper_gazebo_plugins/spline.hpp>
+
 #include <hrim_actuator_gripper_msgs/msg/state_gripper.hpp>
 #include <hrim_actuator_gripper_msgs/msg/state_finger_gripper.hpp>
 #include <hrim_actuator_gripper_srvs/srv/specs_finger_gripper.hpp>
@@ -89,6 +91,9 @@ namespace gazebo
     // Documentation inherited.
     public: void Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
+    /// \ brief Handle wimulation reset.
+    public: void Reset();
+
     /// \brief World pointer.
     private: gazebo::physics::WorldPtr world;
 
@@ -133,6 +138,13 @@ namespace gazebo
 
     double targetJoint  = 0.0;
     double targetRotation  = 0.0;
+
+    std::vector<float> interpolated_targetJoint;
+
+    double current_pose_rad = 0.0;
+
+    bool executing_joints;
+    unsigned int index_executing_joints;
 
     /// A pointer to the GazeboROS node.
     gazebo_ros::Node::SharedPtr ros_node_;

--- a/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
+++ b/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
@@ -137,7 +137,9 @@ namespace gazebo
     double cmdmin = -10.0;
 
     double targetJoint  = 0.0;
+    double targetJoint_goal = 0.0;
     double targetRotation  = 0.0;
+    double targetRotation_goal = 0.0;
 
     std::vector<float> interpolated_targetJoint;
 

--- a/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/spline.hpp
+++ b/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/spline.hpp
@@ -1,0 +1,114 @@
+/*
+ * spline.h
+ *
+ * simple cubic spline interpolation library without external
+ * dependencies
+ *
+ * ---------------------------------------------------------------------
+ * Copyright (C) 2011, 2014 Tino Kluge (ttk448 at gmail.com)
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ *
+ */
+
+
+#ifndef TK_SPLINE_H
+#define TK_SPLINE_H
+
+#include <cstdio>
+//#include <cassert>
+#include <vector>
+#include <algorithm>
+
+
+namespace tk
+{
+
+  // band matrix solver
+  class band_matrix
+  {
+  private:
+      std::vector< std::vector<double> > m_upper;  // upper band
+      std::vector< std::vector<double> > m_lower;  // lower band
+  public:
+      band_matrix() {};                             // constructor
+      band_matrix(int dim, int n_u, int n_l);       // constructor
+      ~band_matrix() {};                            // destructor
+      bool resize(int dim, int n_u, int n_l);      // init with dim,n_u,n_l
+      int dim() const;                             // matrix dimension
+      int num_upper() const
+      {
+          return m_upper.size()-1;
+      }
+      int num_lower() const
+      {
+          return m_lower.size()-1;
+      }
+      // access operator
+      double & operator () (int i, int j);            // write
+      double   operator () (int i, int j) const;      // read
+      // we can store an additional diogonal (in m_lower)
+      double& saved_diag(int i);
+      double  saved_diag(int i) const;
+      void lu_decompose();
+      std::vector<double> r_solve(const std::vector<double>& b);
+      std::vector<double> l_solve(const std::vector<double>& b);
+      std::vector<double> lu_solve(const std::vector<double>& b,
+                                   bool is_lu_decomposed=false);
+      bool success;
+
+  };
+
+
+  // spline interpolation
+  class spline
+  {
+  public:
+      enum bd_type {
+          first_deriv = 1,
+          second_deriv = 2
+      };
+
+  private:
+      std::vector<double> m_x,m_y;            // x,y coordinates of points
+      // interpolation parameters
+      // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
+      std::vector<double> m_a,m_b,m_c;        // spline coefficients
+      double  m_b0, m_c0;                     // for left extrapol
+      bd_type m_left, m_right;
+      double  m_left_value, m_right_value;
+      bool    m_force_linear_extrapolation;
+
+  public:
+      // set default boundary condition to be zero curvature at both ends
+      spline(): m_left(second_deriv), m_right(second_deriv),
+          m_left_value(0.0), m_right_value(0.0),
+          m_force_linear_extrapolation(false)
+      {
+          ;
+      }
+
+      // optional, but if called it has to come be before set_points()
+      void set_boundary(bd_type left, double left_value,
+                        bd_type right, double right_value,
+                        bool force_linear_extrapolation=false);
+      bool set_points(const std::vector<double>& x,
+                      const std::vector<double>& y, bool cubic_spline=true);
+      double operator() (double x) const;
+  };
+
+} // namespace tk
+
+#endif /* TK_SPLINE_H */

--- a/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
@@ -58,16 +58,9 @@ namespace gazebo
       targetJoint = request->goal_linearposition;
       targetRotation = request->goal_angularposition;
 
-      //////// new code
       double current_pose_rad = this->model->GetJointController()->GetPositions().begin()->second; //Taking first joint for reference only, this should be improved
       double start_time = 0;
-      std::cout << "\ngripper_service prints" <<std::endl;
-      std::cout << current_pose_rad <<std::endl;
-      std::cout << targetJoint <<std::endl;
-      std::cout << MaxVelocity <<std::endl;
-
       double end_time = fabs(current_pose_rad - targetJoint) / MaxVelocity;
-      std::cout << end_time <<std::endl;
 
       std::vector<double> X(2), Y_pos(2);
       X[0] = start_time;
@@ -82,7 +75,6 @@ namespace gazebo
       for(double t = start_time; t < end_time; t+=0.001 ){
         interpolated_targetJoint.push_back(interpolation_linear_pos(t));
       }
-      //////// new code
 
       UpdateJointPIDs();
 

--- a/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
@@ -51,26 +51,55 @@ namespace gazebo
         const std::shared_ptr<hrim_actuator_gripper_srvs::srv::ControlFinger::Request> request,
         std::shared_ptr<hrim_actuator_gripper_srvs::srv::ControlFinger::Response> response)
   {
-    (void)request_header;
+    if(!executing_joints){
+      (void)request_header;
 
-    targetJoint = request->goal_linearposition;
-    targetRotation = request->goal_angularposition;
+      interpolated_targetJoint.clear();
+      targetJoint = request->goal_linearposition;
+      targetRotation = request->goal_angularposition;
 
-    UpdateJointPIDs();
+      //////// new code
+      double current_pose_rad = this->model->GetJointController()->GetPositions().begin()->second; //Taking first joint for reference only, this should be improved
+      double start_time = 0;
+      std::cout << "\ngripper_service prints" <<std::endl;
+      std::cout << current_pose_rad <<std::endl;
+      std::cout << targetJoint <<std::endl;
+      std::cout << MaxVelocity <<std::endl;
 
-    auto jointPIDS = this->model->GetJointController()->GetPositionPIDs();
+      double end_time = fabs(current_pose_rad - targetJoint) / MaxVelocity;
+      std::cout << end_time <<std::endl;
 
-    gzmsg << "Position PID parameters for joints "  << std::endl
-          << "\tKP: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetPGain()  << std::endl
-          << "\tKI: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetIGain()  << std::endl
-          << "\tKD: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetDGain()  << std::endl
-          << "\tIMin: "   << jointPIDS[joint_v_.front()->GetScopedName()].GetIMin()   << std::endl
-          << "\tIMax: "   << jointPIDS[joint_v_.front()->GetScopedName()].GetIMax()   << std::endl
-          << "\tCmdMin: " << jointPIDS[joint_v_.front()->GetScopedName()].GetCmdMin() << std::endl
-          << "\tCmdMax: " << jointPIDS[joint_v_.front()->GetScopedName()].GetCmdMax() << std::endl
-          << std::endl;
+      std::vector<double> X(2), Y_pos(2);
+      X[0] = start_time;
+      X[1] = end_time;
+      Y_pos[0] = current_pose_rad;
+      Y_pos[1] = targetJoint;
 
-    response->goal_accepted = true;
+      tk::spline interpolation_linear_pos;
+      if(!interpolation_linear_pos.set_points(X, Y_pos))
+        return;
+
+      for(double t = start_time; t < end_time; t+=0.001 ){
+        interpolated_targetJoint.push_back(interpolation_linear_pos(t));
+      }
+      //////// new code
+
+      UpdateJointPIDs();
+
+      auto jointPIDS = this->model->GetJointController()->GetPositionPIDs();
+
+      gzmsg << "Position PID parameters for joints "  << std::endl
+            << "\tKP: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetPGain()  << std::endl
+            << "\tKI: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetIGain()  << std::endl
+            << "\tKD: "     << jointPIDS[joint_v_.front()->GetScopedName()].GetDGain()  << std::endl
+            << "\tIMin: "   << jointPIDS[joint_v_.front()->GetScopedName()].GetIMin()   << std::endl
+            << "\tIMax: "   << jointPIDS[joint_v_.front()->GetScopedName()].GetIMax()   << std::endl
+            << "\tCmdMin: " << jointPIDS[joint_v_.front()->GetScopedName()].GetCmdMin() << std::endl
+            << "\tCmdMax: " << jointPIDS[joint_v_.front()->GetScopedName()].GetCmdMax() << std::endl
+            << std::endl;
+
+      response->goal_accepted = true;
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -269,6 +298,11 @@ namespace gazebo
       }
     }
 
+    interpolated_targetJoint.clear();
+    executing_joints = false;
+    index_executing_joints = 0.0;
+    targetJoint = 0.0;
+
     std::function<void( std::shared_ptr<rmw_request_id_t>,
                         const std::shared_ptr<hrim_actuator_gripper_srvs::srv::ControlFinger::Request>,
                         std::shared_ptr<hrim_actuator_gripper_srvs::srv::ControlFinger::Response>)> cb_fingercontrol_function = std::bind(
@@ -309,6 +343,20 @@ namespace gazebo
 
   void RobotiqGripperPlugin::UpdatePIDControl()
   {
+    if(!executing_joints && interpolated_targetJoint.size()>0){
+        index_executing_joints = 0;
+        executing_joints = true;
+    }
+    if(executing_joints){
+      targetJoint = interpolated_targetJoint[index_executing_joints];
+      index_executing_joints++;
+      if(index_executing_joints==interpolated_targetJoint.size()){
+        executing_joints = false;
+        interpolated_targetJoint.clear();
+        index_executing_joints = 0;
+      }
+    }
+
     // Set the joint's target velocity.
     for(auto &joint : this->joint_v_){
       this->model->GetJointController()->SetPositionTarget(
@@ -320,6 +368,13 @@ namespace gazebo
           rotation->GetScopedName(), targetRotation * rotation_multipliers_[rotation->GetScopedName()]);
       }
     }
+  }
+
+  void RobotiqGripperPlugin::Reset()
+  {
+    interpolated_targetJoint.clear();
+    targetJoint = 0;
+    executing_joints = false;
   }
 
   void RobotiqGripperPlugin::createGenericTopics(std::string node_name)

--- a/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
@@ -55,18 +55,18 @@ namespace gazebo
       (void)request_header;
 
       interpolated_targetJoint.clear();
-      targetJoint = request->goal_linearposition;
-      targetRotation = request->goal_angularposition;
+      targetJoint_goal = request->goal_linearposition;
+      targetRotation_goal = request->goal_angularposition;
 
       double current_pose_rad = this->model->GetJointController()->GetPositions().begin()->second; //Taking first joint for reference only, this should be improved
       double start_time = 0;
-      double end_time = fabs(current_pose_rad - targetJoint) / MaxVelocity;
+      double end_time = fabs(current_pose_rad - targetJoint_goal) / MaxVelocity;
 
       std::vector<double> X(2), Y_pos(2);
       X[0] = start_time;
       X[1] = end_time;
       Y_pos[0] = current_pose_rad;
-      Y_pos[1] = targetJoint;
+      Y_pos[1] = targetJoint_goal;
 
       tk::spline interpolation_linear_pos;
       if(!interpolation_linear_pos.set_points(X, Y_pos))

--- a/robotiq_gripper_gazebo_plugins/src/spline.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/spline.cpp
@@ -1,0 +1,347 @@
+#include "mara_gazebo_plugins/spline.hpp"
+namespace tk
+{
+  // band_matrix implementation
+  // -------------------------
+
+  band_matrix::band_matrix(int dim, int n_u, int n_l)
+  {
+    success = true;
+
+    if( !resize(dim, n_u, n_l) ){
+      printf("resize error!\n");
+      success = false;
+    }
+  }
+
+  bool band_matrix::resize(int dim, int n_u, int n_l)
+  {
+      // assert(dim>0);
+      // assert(n_u>=0);
+      // assert(n_l>=0);
+      if( !(dim>0) || !(n_u>=0) || !(n_l>=0)){
+        printf("resize inside error!\n");
+        return false;
+      }
+
+      m_upper.resize(n_u+1);
+      m_lower.resize(n_l+1);
+      for(size_t i=0; i<m_upper.size(); i++) {
+          m_upper[i].resize(dim);
+      }
+      for(size_t i=0; i<m_lower.size(); i++) {
+          m_lower[i].resize(dim);
+      }
+      return true;
+  }
+
+  int band_matrix::dim() const
+  {
+      if(m_upper.size()>0) {
+          return m_upper[0].size();
+      } else {
+          return 0;
+      }
+  }
+
+  // defines the new operator (), so that we can access the elements
+  // by A(i,j), index going from i=0,...,dim()-1
+  double & band_matrix::operator () (int i, int j)
+  {
+      int k=j-i;       // what band is the entry
+      // assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+      // assert( (-num_lower()<=k) && (k<=num_upper()) );
+      // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+      if(k>=0)   return m_upper[k][i];
+      else	    return m_lower[-k][i];
+  }
+
+  double band_matrix::operator () (int i, int j) const
+  {
+      int k=j-i;       // what band is the entry
+      // assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+      // assert( (-num_lower()<=k) && (k<=num_upper()) );
+      // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+      if(k>=0)   return m_upper[k][i];
+      else	    return m_lower[-k][i];
+  }
+
+  // second diag (used in LU decomposition), saved in m_lower
+  double band_matrix::saved_diag(int i) const
+  {
+      //assert( (i>=0) && (i<dim()) );
+      return m_lower[0][i];
+  }
+
+  double & band_matrix::saved_diag(int i)
+  {
+      //assert( (i>=0) && (i<dim()) );
+      return m_lower[0][i];
+  }
+
+  // LR-Decomposition of a band matrix
+  void band_matrix::lu_decompose()
+  {
+      int  i_max,j_max;
+      int  j_min;
+      double x;
+
+      // preconditioning
+      // normalize column i so that a_ii=1
+      for(int i=0; i<this->dim(); i++) {
+          //assert(this->operator()(i,i)!=0.0);
+          if( this->operator()(i,i)==0.0 )
+          {
+            printf("this->operator()(i,i)==0.0\n");
+
+            success = false;
+            return;
+          }
+          this->saved_diag(i)=1.0/this->operator()(i,i);
+          j_min=std::max(0,i-this->num_lower());
+          j_max=std::min(this->dim()-1,i+this->num_upper());
+          for(int j=j_min; j<=j_max; j++) {
+              this->operator()(i,j) *= this->saved_diag(i);
+          }
+          this->operator()(i,i)=1.0;          // prevents rounding errors
+      }
+
+      // Gauss LR-Decomposition
+      for(int k=0; k<this->dim(); k++) {
+          i_max=std::min(this->dim()-1,k+this->num_lower());  // num_lower not a mistake!
+          for(int i=k+1; i<=i_max; i++) {
+              //assert(this->operator()(k,k)!=0.0);
+              if( this->operator()(k,k)==0.0 )
+              {
+                printf("this->operator()(k,k)==0.0 \n");
+
+                success = false;
+                return;
+              }
+              x=-this->operator()(i,k)/this->operator()(k,k);
+              this->operator()(i,k)=-x;                         // assembly part of L
+              j_max=std::min(this->dim()-1,k+this->num_upper());
+              for(int j=k+1; j<=j_max; j++) {
+                  // assembly part of R
+                  this->operator()(i,j)=this->operator()(i,j)+x*this->operator()(k,j);
+              }
+          }
+      }
+  }
+
+  // solves Ly=b
+  std::vector<double> band_matrix::l_solve(const std::vector<double>& b)
+  {
+      //assert( this->dim()==(int)b.size() );
+      if( this->dim()!=(int)b.size() )
+      {
+        printf("this->dim()!=(int)b.size() \n");
+
+        success = false;
+        return std::vector<double>();
+      }
+      std::vector<double> x(this->dim());
+      int j_start;
+      double sum;
+      for(int i=0; i<this->dim(); i++) {
+          sum=0;
+          j_start=std::max(0,i-this->num_lower());
+          for(int j=j_start; j<i; j++) sum += this->operator()(i,j)*x[j];
+          x[i]=(b[i]*this->saved_diag(i)) - sum;
+      }
+      return x;
+  }
+
+  // solves Rx=y
+  std::vector<double> band_matrix::r_solve(const std::vector<double>& b)
+  {
+      //assert( this->dim()==(int)b.size() );
+      if( this->dim()!=(int)b.size() )
+      {
+        printf("this->dim()!=(int)b.size() \n");
+
+        success = false;
+        return std::vector<double>();
+      }
+      std::vector<double> x(this->dim());
+      int j_stop;
+      double sum;
+      for(int i=this->dim()-1; i>=0; i--) {
+          sum=0;
+          j_stop=std::min(this->dim()-1,i+this->num_upper());
+          for(int j=i+1; j<=j_stop; j++) sum += this->operator()(i,j)*x[j];
+          x[i]=( b[i] - sum ) / this->operator()(i,i);
+      }
+      return x;
+  }
+
+  std::vector<double> band_matrix::lu_solve(const std::vector<double>& b,
+          bool is_lu_decomposed)
+  {
+      //assert( this->dim()==(int)b.size() );
+      if( this->dim()!=(int)b.size() )
+      {
+        printf(" this->dim()!=(int)b.size()\n");
+
+        success = false;
+        return  std::vector<double>();
+      }
+      std::vector<double>  x,y;
+      if(is_lu_decomposed==false) {
+          this->lu_decompose();
+          if(!success)
+            return  std::vector<double>();
+      }
+      y=this->l_solve(b);
+      x=this->r_solve(y);
+      return x;
+  }
+
+  // spline implementation
+  // -----------------------
+
+  void spline::set_boundary(spline::bd_type left, double left_value,
+                            spline::bd_type right, double right_value,
+                            bool force_linear_extrapolation)
+  {
+      //assert(m_x.size()==0);          // set_points() must not have happened yet
+      m_left=left;
+      m_right=right;
+      m_left_value=left_value;
+      m_right_value=right_value;
+      m_force_linear_extrapolation=force_linear_extrapolation;
+  }
+
+  bool spline::set_points(const std::vector<double>& x,
+                          const std::vector<double>& y, bool cubic_spline)
+  {
+      if(x.size()!=y.size())
+        return false;
+      if(x.size()<2)
+        return false;
+
+      m_x=x;
+      m_y=y;
+      int n=x.size();
+      // TODO: maybe sort x and y, rather than returning an error
+
+      for(int i=0; i<n-1; i++) {
+        if(m_x[i]>m_x[i+1]){
+          printf("m_x[i]>m_x[i+1]\n");
+          return false;
+        }
+      }
+
+      if(cubic_spline==true) { // cubic spline interpolation
+          // setting up the matrix and right hand side of the equation system
+          // for the parameters b[]
+          band_matrix A(n,1,1);
+          if( !A.success ){
+            printf("242\n");
+            return false;
+          }
+
+          std::vector<double>  rhs(n);
+          for(int i=1; i<n-1; i++) {
+              A(i,i-1)=1.0/3.0*(x[i]-x[i-1]);
+              A(i,i)=2.0/3.0*(x[i+1]-x[i-1]);
+              A(i,i+1)=1.0/3.0*(x[i+1]-x[i]);
+              rhs[i]=(y[i+1]-y[i])/(x[i+1]-x[i]) - (y[i]-y[i-1])/(x[i]-x[i-1]);
+          }
+          // boundary conditions
+          if(m_left == spline::second_deriv) {
+              // 2*b[0] = f''
+              A(0,0)=2.0;
+              A(0,1)=0.0;
+              rhs[0]=m_left_value;
+          } else if(m_left == spline::first_deriv) {
+              // c[0] = f', needs to be re-expressed in terms of b:
+              // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
+              A(0,0)=2.0*(x[1]-x[0]);
+              A(0,1)=1.0*(x[1]-x[0]);
+              rhs[0]=3.0*((y[1]-y[0])/(x[1]-x[0])-m_left_value);
+          } else {
+            return false;
+          }
+          if(m_right == spline::second_deriv) {
+              // 2*b[n-1] = f''
+              A(n-1,n-1)=2.0;
+              A(n-1,n-2)=0.0;
+              rhs[n-1]=m_right_value;
+          } else if(m_right == spline::first_deriv) {
+              // c[n-1] = f', needs to be re-expressed in terms of b:
+              // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
+              // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
+              A(n-1,n-1)=2.0*(x[n-1]-x[n-2]);
+              A(n-1,n-2)=1.0*(x[n-1]-x[n-2]);
+              rhs[n-1]=3.0*(m_right_value-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
+          } else {
+            return false;
+          }
+
+          // solve the equation system to obtain the parameters b[]
+          m_b=A.lu_solve(rhs);
+          if( !A.success ){
+            printf("287\n");
+            return false;
+          }
+
+          // calculate parameters a[] and c[] based on b[]
+          m_a.resize(n);
+          m_c.resize(n);
+          for(int i=0; i<n-1; i++) {
+              m_a[i]=1.0/3.0*(m_b[i+1]-m_b[i])/(x[i+1]-x[i]);
+              m_c[i]=(y[i+1]-y[i])/(x[i+1]-x[i])
+                     - 1.0/3.0*(2.0*m_b[i]+m_b[i+1])*(x[i+1]-x[i]);
+          }
+      } else { // linear interpolation
+          m_a.resize(n);
+          m_b.resize(n);
+          m_c.resize(n);
+          for(int i=0; i<n-1; i++) {
+              m_a[i]=0.0;
+              m_b[i]=0.0;
+              m_c[i]=(m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
+          }
+      }
+
+      // for left extrapolation coefficients
+      m_b0 = (m_force_linear_extrapolation==false) ? m_b[0] : 0.0;
+      m_c0 = m_c[0];
+
+      // for the right extrapolation coefficients
+      // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
+      double h=x[n-1]-x[n-2];
+      // m_b[n-1] is determined by the boundary condition
+      m_a[n-1]=0.0;
+      m_c[n-1]=3.0*m_a[n-2]*h*h+2.0*m_b[n-2]*h+m_c[n-2];   // = f'_{n-2}(x_{n-1})
+      if(m_force_linear_extrapolation==true)
+          m_b[n-1]=0.0;
+
+      return true;
+  }
+
+  double spline::operator() (double x) const
+  {
+      size_t n=m_x.size();
+      // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+      std::vector<double>::const_iterator it;
+      it=std::lower_bound(m_x.begin(),m_x.end(),x);
+      int idx=std::max( int(it-m_x.begin())-1, 0);
+
+      double h=x-m_x[idx];
+      double interpol;
+      if(x<m_x[0]) {
+          // extrapolation to the left
+          interpol=(m_b0*h + m_c0)*h + m_y[0];
+      } else if(x>m_x[n-1]) {
+          // extrapolation to the right
+          interpol=(m_b[n-1]*h + m_c[n-1])*h + m_y[n-1];
+      } else {
+          // interpolation
+          interpol=((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+      }
+      return interpol;
+  }
+
+} // namespace tk

--- a/robotiq_gripper_gazebo_plugins/src/spline.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/spline.cpp
@@ -1,4 +1,4 @@
-#include "mara_gazebo_plugins/spline.hpp"
+#include "robotiq_gripper_gazebo_plugins/spline.hpp"
 namespace tk
 {
   // band_matrix implementation


### PR DESCRIPTION
Improved grippers general behavior
 - Added a Reset() function to handle simulation reset properly.
 - Added interpolation. Previously new goals where executed instantly. 

Note that interpolation's duration is calculated using the `MaxVelocity` variable available in the header file:
```cpp
    /// \brief Max. joint speed (rad/s). Finger is 125mm and tip speed is 110mm/s.
    private: const double MaxVelocity = 0.88;
```
Maybe we should add gripping speed to the URDF file? Or provide a service call to tune it?

Also to provide more accurate visual speed we should not rely on the connection update event to push the next interpolation pose to gazebo. Instead a 1ms (matching interpolation time increment) wall timer would be better (I think).

**Note**: The blue point is a non colliding object, only visual.
![gripping](https://user-images.githubusercontent.com/16973377/55211609-5e3c8880-521f-11e9-9d1e-64989c8eff07.gif)


---
We have some physics problems as you can see in the image below. I'll try to improve it and make a new PR. ( the robot is shaking because im executing new actions continuously, + using the old driver. This won't happen in a real simulation scenario)
![grip_fail](https://user-images.githubusercontent.com/16973377/55212247-9c3aac00-5221-11e9-80cf-167ed91c56b6.gif)
