### PR TITLE
take info from joint_finger

### DIFF
--- a/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
+++ b/robotiq_gripper_gazebo_plugins/include/robotiq_gripper_gazebo_plugins/RobotiqGripperPlugin.h
@@ -56,6 +56,7 @@ namespace gazebo
       std::vector<physics::JointPtr> jointsVec;
       std::map<std::string, double> joint_multipliers_;
 
+      double upper_limit;
       double target_pose;
       double target_velocity;
 

--- a/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
+++ b/robotiq_gripper_gazebo_plugins/src/RobotiqGripperPlugin.cpp
@@ -18,8 +18,6 @@ namespace gazebo{
       (void)request_header;
 
       // Pose control
-      double upper_limit = jointsVec[0]->UpperLimit(0);
-
       if((int)this->joint_type == 1088){ // prismatic
         target_pose = request->goal_linearposition;
       }
@@ -144,8 +142,9 @@ namespace gazebo{
       auto joint_name = joint_elem->Get<std::string>();
       auto joint = model->GetJoint(joint_name);
 
-      if(joint_name.find("joint_finger")){
+      if(joint_name.find("joint_finger") != std::string::npos){
         this->joint_type = this->model->GetJoint(joint_name)->GetType();
+        upper_limit = joint->UpperLimit(0);
       }
 
       if(!joint){


### PR DESCRIPTION
Fix https://github.com/AcutronicRobotics/robotiq_modular_gripper/issues/16.

Instead of changing all the URDFs and make mandatory the joint_finger to be the first joint in the model, i have fixed the find condition and i have added the upper_limit assignation there.